### PR TITLE
Fix displayed coverage

### DIFF
--- a/RangeExtensions.Tests/Properties.cs
+++ b/RangeExtensions.Tests/Properties.cs
@@ -1,0 +1,3 @@
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: ExcludeFromCodeCoverage]

--- a/RangeExtensions.Tests/Properties.cs
+++ b/RangeExtensions.Tests/Properties.cs
@@ -1,3 +1,5 @@
+#if !NET48
 using System.Diagnostics.CodeAnalysis;
 
 [assembly: ExcludeFromCodeCoverage]
+#endif

--- a/RangeExtensions.Tests/RangeExtensions.Tests.csproj
+++ b/RangeExtensions.Tests/RangeExtensions.Tests.csproj
@@ -9,6 +9,7 @@
     <WarningsAsErrors>nullable</WarningsAsErrors>
 
     <IsPackable>false</IsPackable>
+    <Exclude>RangeExtensions.Tests.AssertHelpers*</Exclude>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Mark tests assembly with `ExcludeFromCodeCoverage` because it has been creating noise for coverage analysis by either analyzing the lines that don't matter or straight up incorrectly calculating it for local methods or exception-checking asserts.